### PR TITLE
Fix jscolor resize

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -362,11 +362,11 @@ function checkRainbow(s) {
     var hasrainbow = s.search(/rainbow/i);
     var gadget;
     if (hasrainbow !== -1) {
-	    gadget = document.getElementById('color_gadget');
-	    gadget.style.display = 'block';
+        gadget = document.getElementById('color_gadget');
+        gadget.style.display = 'block';
     } else {
-	    gadget = document.getElementById('color_gadget');
-	    gadget.style.display = 'none';
+        gadget = document.getElementById('color_gadget');
+        gadget.style.display = 'none';
     }
 }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -363,12 +363,13 @@ function selectTab(e) {
 
 function checkRainbow(s) {
     var hasrainbow = s.search(/rainbow/i);
-    if (hasrainbow != -1) {
-	var gadget = document.getElementById('color_gadget');
-	gadget.style.display = 'block';
+    var gadget;
+    if (hasrainbow !== -1) {
+	    gadget = document.getElementById('color_gadget');
+	    gadget.style.display = 'block';
     } else {
-	var gadget = document.getElementById('color_gadget');
-	gadget.style.display = 'none';
+	    gadget = document.getElementById('color_gadget');
+	    gadget.style.display = 'none';
     }
 }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -490,7 +490,7 @@ function loadLocalSketch(e) {
 
     editor.setValue(sketch.document);
     checkRainbow(sketch.document);
-    
+
     selectTab('code_editor');
     editor.refresh();
 
@@ -524,7 +524,7 @@ function uploadSketch(e) {
         return function (e) {
             editor.setValue(e.target.result);
 	    checkRainbow(e.target.result);
-	    
+
             selectTab('code_editor');
             editor.refresh();
             elt.value = null;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -284,14 +284,11 @@ function initializeEditor() {
 }
 
 function resizeHeader() {
+    checkRainbow(editor.getValue());
     var header = document.getElementById('Site-header');
     var height = header.offsetHeight;
     document.getElementById('main').style.marginTop = height + 'px';
     header.style.top = 0;
-
-
-    var gadget = document.getElementById('color_gadget');
-    gadget.style.display = 'none';
 }
 
 function installHooks() {
@@ -394,7 +391,7 @@ function loadExampleFromLink(e) {
 
             if (request.status === 200) {
                 editor.setValue(request.responseText);
-		checkRainbow(request.responseText);
+                resizeHeader();
             }
         }
     };
@@ -490,7 +487,7 @@ function loadLocalSketch(e) {
     }
 
     editor.setValue(sketch.document);
-    checkRainbow(sketch.document);
+    resizeHeader();
 
     selectTab('code_editor');
     editor.refresh();
@@ -524,7 +521,7 @@ function uploadSketch(e) {
     reader.onload = (function (contents) {
         return function (e) {
             editor.setValue(e.target.result);
-	    checkRainbow(e.target.result);
+            resizeHeader();
 
             selectTab('code_editor');
             editor.refresh();


### PR DESCRIPTION
I noticed an issue with the jscolor resize, where there was always a gap at the top of the window unless the color picker needs to be shown.

This patch makes the color picker test part of the resize event, and fires a resize event every time the file is replaced.