### PR TITLE
piwik: disable tracking cookies

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -845,7 +845,7 @@ function installPiwik() {
     // accurately measure the time spent on the last pageview of a visit
     window._paq.push(['enableHeartBeatTimer']);
 
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    window._paq.push(['disableCookies']);
     window._paq.push(['trackPageView']);
     window._paq.push(['enableLinkTracking']);
     (function () {


### PR DESCRIPTION
Cookies are a problem for certain jurisdictions, so disable them for
now.

Signed-off-by: Sean Cross <sean@xobs.io>